### PR TITLE
Missing Slider Mobile 750x400 Size Addition

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -310,3 +310,12 @@ function remove_tiqets_inline_scripts($content) {
     return preg_replace('/<script[^>]*widgets\.tiqets\.com\/loader\.js[^>]*><\/script>/', '', $content);
 }
 add_filter('the_content', 'remove_tiqets_inline_scripts', 10);
+
+/**
+ * Add custom image size for mobile slider images
+ * 
+ * Image size: 750x400px was missing from the theme
+*/
+add_action('after_setup_theme', function() {
+    add_image_size('base_hotel_img_mobile', 750, 400, true);
+});


### PR DESCRIPTION
Images like `https://autentical.nl/wp-content/uploads/sites/42/2017/08/el-rocio-1-750x400.jpg` fail loading on homepage slider mobile for `autentical.nl` and other slider images with same format on mobile are no longer available. This is also the case on other locations like on the `autentical.es` homepage. 

Not clear why they have gone missing and why there was no such `add_image_size` option (anymore). Likely cause is removal or change of the `add_image_size` for that format. This could also be the cause for why so many images are missing. Only not clear why the older images with that format were removed after changes were made.

This pull request includes a minor addition to the `functions.php` file. The change introduces a new custom image size for mobile slider images, which was previously missing from the site as size and for which images are missing on server.  New size will have to be generated on the server with `wp-cli` See instructions that will follow.

### Theme Enhancements:

* [`functions.php`](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556R313-R321): Added a custom image size `base_hotel_img_mobile` with dimensions 750x400px for mobile slider images.


### Current Image Sizes
```sh
wp media image-size
+-------------------------------------+-------+--------+------+-------+
| name                                | width | height | crop | ratio |
+-------------------------------------+-------+--------+------+-------+
| full                                |       |        | N/A  | N/A   |
| 2048x2048                           | 2048  | 2048   | soft | N/A   |
| base_hotel_img_slideshow_home_large | 2000  | 1100   | hard | 20:11 |
| base_hotel_img_slideshow_home       | 1800  | 800    | hard | 9:4   |
| 1536x1536                           | 1536  | 1536   | soft | N/A   |
| base_hotel_img_slideshow_large      | 1200  | 600    | hard | 2:1   |
| base_hotel_img_special_banner       | 1200  | 400    | hard | 3:1   |
| base_hotel_img_gallery              | 900   | 900    | soft | N/A   |
| base_hotel_img_slideshow            | 770   | 500    | hard | 77:50 |
| medium_large                        | 768   | 0      | soft | N/A   |
| base_hotel_img_special_sidebar      | 380   | 250    | hard | 38:25 |
| base_hotel_img_room_thumb           | 380   | 380    | hard | 1:1   |
+-------------------------------------+-------+--------+------+-------+
```

### Verify new size is registered

to verify newly added size after child theme update with newly added image size  use:
```
wp media image-size
```

#### Regenerate thumbnails for newly added image size
```
wp media regenerate --only-missing --image_size=base_hotel_img_mobile --yes
```

#### Verification 
```
ls -l /var/www/autentical.com/public_html/wp-content/uploads/sites/42/2017/08/el-rocio-1-750x400.jpg
```